### PR TITLE
Add `go-add-tags` and `go-remove-tags` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,42 @@
 # golang.kak
-**golang.kak** brings additional Go functionality to [Kakoune], implementing some features from [vim-go]. It provides alternate file switching (switching from a `.go` file to its `_test.go` file, or between Go module files), and commands to run Go unit tests and display test file coverage. It does not aim to implement all features found in [vim-go], but just enough of them to provide useful additions to Kakoune's out-of-the-box Go support.
+**golang.kak** brings additional Go functionality to [Kakoune], implementing some of the features found in [vim-go]. Over Kakoune's built-in Go functionality, it provides:
+
+* Syntax highlighting for Go module files (`go.mod` and `go.sum`),
+* Alternate file switching (switch from a `.go` file to its `_test.go` file, or between `go.mod` and `go.sum` files) via `go-alternate`,
+* Execution of Go unit tests via `go-test`,
+* Display test file coverage in the current buffer via `go-coverage`, and
+* Some basic struct tag handling via `go-add-tags` and `go-remove-tags`.
+
+It does not aim to implement all features found in [vim-go], but just enough of them to provide useful additions to Kakoune's out-of-the-box Go support.
+
+## Dependencies
+`golang.kak` requires [gomodifytags] in order to add/remove struct tags. `gomodifytags` can be installed by running:
+
+```
+go get github.com/fatih/gomodifytags
+```
+
+If the `gomodifytags` binary is not found in `$GOBIN`, the plugin will output an error indicating this on startup (future versions of the plugin will provide a better UI around tooling dependencies).
 
 ## Installation
 Choose one of the following installation methods:
 1. Add [`golang.kak`](rc/golang.kak) to your autoload directory
 2. Source manually
-3. Install via [plug.kak]
+3. Install via [plug.kak] or similar plugin managers
 
 ## Usage
-**golang.kak** currently provides three commands:
+**golang.kak** provides five commands:
 
 Command | Description
 ------- | -----------
-`go-test` | Run tests in the current package. Currently the test status is displayed in the modeline.
-`go-coverage` | Display test coverage highlighters in the current file, if it is a `.go` file. Run the command again to remove coverage highlights.
-`go-alternate`| Switch from a `.go` file to its associated `_test.go` file, if one exists, or vice versa. Also switches between `go.mod` and `go.sum` files.
-
-**golang.kak** also provides syntax highlighting for `go.mod` and `go.sum` files.
+<nobr>`go-test`|Run tests in the current package. Currently the test status is displayed in the modeline.
+<nobr>`go-coverage`|Display test coverage highlighters in the current file, if it is a `.go` file. Run the command again to remove coverage highlights.
+<nobr>`go-alternate`|Switch from a `.go` file to its associated `_test.go` file, if one exists, or vice versa. Also switches between `go.mod` and `go.sum` files.
+<nobr>`go-add-tags`|Add the specified tag (or tags, as a comma-separated list) to the struct the cursor is currently within. `go-add-tags` is additive, and each successive execution within a struct will add new tags to its fields.
+<nobr>`go-remove-tags`|Remove a specified tag (or tags, as a comma-separated list) from the struct the cursor is currently within. `go-remove-tags` is subtractive and each successive execution within a struct will remove further tags from its fields.
 
 ## Configuration
-**golang.kak**'s default highlighters for Go module files and unit test coverage are globally defined, and can be overridden after **golang.kak** has been loaded:
+**golang.kak** does not require any specific configuration. However, its provided highlighters for Go module files and unit test coverage are globally defined, and can be overridden after **golang.kak** has been loaded:
 
 ### Module files
 Face | Description
@@ -42,4 +59,5 @@ This plugin is inspired by [vim-go]; therefore grateful thanks are due to Fatih 
 [Kakoune]: https://kakoune.org
 [vim-go]: https://github.com/fatih/vim-go
 [plug.kak]: https://github.com/andreyorst/plug.kak
+[gomodifytags]: https://github.com/fatih/gomodifytags
 


### PR DESCRIPTION
Adds new commands for basic handling of struct tags, fixes some commentary typos